### PR TITLE
matches.points カラム削除

### DIFF
--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -7,4 +7,8 @@ class Match < ApplicationRecord
   has_one    :qualifier_match
 
   after_commit { team.aggregate_points; opponent.aggregate_points }
+
+  def points(team)
+    self.team == team ? team_points : opponent_points
+  end
 end

--- a/app/models/qualifier.rb
+++ b/app/models/qualifier.rb
@@ -10,10 +10,10 @@ class Qualifier < ApplicationRecord
   end
 
   def preinitiation?
-    matches.all? { |m| m.points.blank? }
+    matches.all? { |m| m.team_points.blank? && m.opponent_points.blank? }
   end
 
   def done?
-    matches.all? { |m| m.points.present? }
+    matches.all? { |m| m.team_points.present? && m.opponent_points.present? }
   end
 end

--- a/app/views/events/top.html.erb
+++ b/app/views/events/top.html.erb
@@ -40,7 +40,7 @@
               <td>
                 <% match = q.matches.select { |m| m.team == team }.first %>
                 <div class="row">
-                  <label class="label label-default"><%= team.result(q) %></label>
+                  <label class="label label-default"><%= match.points(team) %></label>
                 </div>
                 <div class="row">
                   vs <%= truncate(match.opponent.name, length: 8) %>

--- a/db/migrate/20171210051553_delete_points_on_matches.rb
+++ b/db/migrate/20171210051553_delete_points_on_matches.rb
@@ -1,0 +1,9 @@
+class DeletePointsOnMatches < ActiveRecord::Migration[5.1]
+  def up
+    remove_column :matches, :points
+  end
+
+  def down
+    add_column :matches, :points, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171103210105) do
+ActiveRecord::Schema.define(version: 20171210051553) do
 
   create_table "events", force: :cascade do |t|
     t.date "held_on"
@@ -23,7 +23,6 @@ ActiveRecord::Schema.define(version: 20171103210105) do
   create_table "matches", force: :cascade do |t|
     t.integer "team_id", null: false
     t.integer "opponent_id", null: false
-    t.integer "points"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "qualifier_id"

--- a/spec/factories/matches.rb
+++ b/spec/factories/matches.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     qualifier
     team
     opponent { FactoryBot.create(:team) }
-    points { [0, 1, 3].sample }
+    team_points { [0, 1, 3].sample }
+    opponent_points { [0, 1, 3].sample }
   end
 end


### PR DESCRIPTION
matchesに自他チームの結果を持たせる構成にしたので、pointsカラムが不要になった。

そのかわりに自分のチームのポイントを取得する同名メソッドを容易