### PR TITLE
Win, Lose のバッヂカラーを変える

### DIFF
--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -14,10 +14,10 @@
   background-color: yellow;
 }
 
-.badge-win {
+span.badge-win {
   background-color: #fa57bf;
 }
 
-.badge-lose {
+span.badge-lose {
   background-color: #43f860;
 }

--- a/app/views/events/top.html.erb
+++ b/app/views/events/top.html.erb
@@ -56,7 +56,7 @@
                 <td>
                   <% opponent = match.team == team ? match.opponent : match.team %>
                   <div class="row <%= 'duplicated' if match.duplicated? %>">
-                    <span class="badge badge-secondary">
+                    <span class="badge badge-secondary <%= 'badge-' + (match.result(team)&.downcase || '') %>">
                       <%= match.result(team) %>
                     </span>
                     <span>


### PR DESCRIPTION
class 指定だと他のスタイルに評価負けてしまったので、spanタグから指定するようにした。

対戦履歴タブのコンテンツにも横展開