### PR TITLE
🐛直近追加したteams.rankカラムが既存のrankメソッドと競合してしまったため

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -15,7 +15,7 @@ class Team < ApplicationRecord
     Match.where(team: self).where.not(team_points: nil).count + Match.where(opponent: self).where.not(opponent_points: nil).count
   end
 
-  def rank
+  def ranking
     event.teams.where('points > ?', points).count + 1
   end
 

--- a/app/views/events/_ranking.html.erb
+++ b/app/views/events/_ranking.html.erb
@@ -11,7 +11,7 @@
   <tbody>
     <% teams.each do |team| %>
       <tr>
-        <td class='rank'><%= team.rank %></td>
+        <td class='rank'><%= team.ranking %></td>
         <td><%= team.name %></td>
         <td class='number'><%= team.match_count %></td>
         <td class='number'><%= team.points %></td>


### PR DESCRIPTION
Team#rank → Team#ranking にrename