### PR TITLE
[#61] マッチングの改善

### DIFF
--- a/app/services/drawer.rb
+++ b/app/services/drawer.rb
@@ -7,7 +7,16 @@ class Drawer
   end
 
   def swiss_draw
-    teams = @qualifier.event.teams.to_a.shuffle.sort_by(&:points)
+    teams = if @qualifier.round <= 2
+              @qualifier.event.teams.to_a.shuffle.sort do |t1, t2|
+                (t2.rank <=> t1.rank).nonzero? || (t2.points <=> t1.points)
+              end
+            else
+              @qualifier.event.teams.to_a.shuffle.sort do |t1, t2|
+                t2.points <=> t1.points
+              end
+            end
+
     matches = []
     loop do
       matches << arrange_match(teams)


### PR DESCRIPTION
1, 2回戦はチームランクと勝点を考慮してマッチさせる。

具合的には、 team.rank, tema.points (ともに降順) で行う。

# Issue

1, 2回戦での虐殺マッチングを解消する #61