### PR TITLE
[#67] 予選n回戦のヘッダ行を昇順になるようにした

### DIFF
--- a/app/views/events/top.html.erb
+++ b/app/views/events/top.html.erb
@@ -36,7 +36,7 @@
         <thead>
           <tr>
             <th>チーム名</th>
-            <% Qualifier.where(event: @event).each do |q| %>
+            <% Qualifier.where(event: @event).order(:round).each do |q| %>
               <th>
                 <%= link_to "#{q.round}回戦", matches_event_qualifier_path(id: q.id, event_id: @event.id) %>
               </th>


### PR DESCRIPTION
# Issue

対戦履歴のヘッダ(n回戦)の表示順がおかしい #67

# ScreenShot

![image](https://user-images.githubusercontent.com/1255116/39393673-ea8770c2-4b02-11e8-8fb7-64adae4d437d.png)
